### PR TITLE
Bugfix/fixed (un)subscribing bugs

### DIFF
--- a/ChatCore/Utilities/DictionaryUtils.cs
+++ b/ChatCore/Utilities/DictionaryUtils.cs
@@ -7,149 +7,132 @@ using System.Text;
 
 namespace ChatCore
 {
-    public static class DictionaryUtils
-    {
-        public static void AddAction(this ConcurrentDictionary<Assembly, Action> dict, Assembly assembly, Action value)
-        {
-            if (!dict.TryGetValue(assembly, out var action))
-            {
-                action = new Action(value);
-                dict[assembly] = action;
-            }
-            action += value;
-        }
-        public static void AddAction<A>(this ConcurrentDictionary<Assembly, Action<A>> dict, Assembly assembly, Action<A> value)
-        {
-            if (!dict.TryGetValue(assembly, out var action))
-            {
-                action = new Action<A>(value);
-                dict[assembly] = action;
-            }
-            action += value;
-        }
-        public static void AddAction<A,B>(this ConcurrentDictionary<Assembly, Action<A,B>> dict, Assembly assembly, Action<A,B> value)
-        {
-            if (!dict.TryGetValue(assembly, out var action))
-            {
-                action = new Action<A,B>(value);
-                dict[assembly] = action;
-            }
-            action += value;
-        }
-        public static void AddAction<A, B, C>(this ConcurrentDictionary<Assembly, Action<A, B, C>> dict, Assembly assembly, Action<A, B, C> value)
-        {
-            if (!dict.TryGetValue(assembly, out var action))
-            {
-                action = new Action<A, B, C>(value);
-                dict[assembly] = action;
-            }
-            action += value;
-        }
+	public static class DictionaryUtils
+	{
+		public static void AddAction(this ConcurrentDictionary<Assembly, Action> dict, Assembly assembly, Action value)
+		{
+			dict.AddOrUpdate(assembly, value, (callingAssembly, existingActions) => existingActions + value);
+		}
 
-        public static void RemoveAction(this ConcurrentDictionary<Assembly, Action> dict, Assembly assembly, Action value)
-        {
-            if (!dict.TryGetValue(assembly, out var action))
-            {
-                return;
-            }
-            action -= value;
-        }
-        public static void RemoveAction<A>(this ConcurrentDictionary<Assembly, Action<A>> dict, Assembly assembly, Action<A> value)
-        {
-            if (!dict.TryGetValue(assembly, out var action))
-            {
-                return;
-            }
-            action -= value;
-        }
-        public static void RemoveAction<A,B>(this ConcurrentDictionary<Assembly, Action<A,B>> dict, Assembly assembly, Action<A,B> value)
-        {
-            if (!dict.TryGetValue(assembly, out var action))
-            {
-                return;
-            }
-            action -= value;
-        }
-        public static void RemoveAction<A, B, C>(this ConcurrentDictionary<Assembly, Action<A, B, C>> dict, Assembly assembly, Action<A, B, C> value)
-        {
-            if (!dict.TryGetValue(assembly, out var action))
-            {
-                return;
-            }
-            action -= value;
-        }
+		public static void AddAction<A>(this ConcurrentDictionary<Assembly, Action<A>> dict, Assembly assembly, Action<A> value)
+		{
+			dict.AddOrUpdate(assembly, value, (callingAssembly, existingActions) => existingActions + value);
+		}
 
-        public static void InvokeAll(this ConcurrentDictionary<Assembly, Action> dict, Assembly assembly, ILogger logger = null)
-        {
-            foreach (var kvp in dict)
-            {
-                if (kvp.Key == assembly)
-                {
-                    continue;
-                }
-                try
-                {
-                    kvp.Value?.Invoke();
-                }
-                catch (Exception ex)
-                {
-                    logger?.LogError(ex, $"An exception occurred while invoking action no params.");
-                }
-            }
-        }
-        public static void InvokeAll<A>(this ConcurrentDictionary<Assembly, Action<A>> dict, Assembly assembly, A a, ILogger logger = null)
-        {
-            foreach (var kvp in dict)
-            {
-                if (kvp.Key == assembly)
-                {
-                    continue;
-                }
-                try
-                {
-                    kvp.Value?.Invoke(a);
-                }
-                catch (Exception ex)
-                {
-                    logger?.LogError(ex, $"An exception occurred while invoking action with param type {typeof(A).Name}");
-                }
-            }
-        }
-        public static void InvokeAll<A, B>(this ConcurrentDictionary<Assembly, Action<A, B>> dict, Assembly assembly, A a, B b, ILogger logger = null)
-        {
-            foreach (var kvp in dict)
-            {
-                if (kvp.Key == assembly)
-                {
-                    continue;
-                }
-                try
-                {
-                    kvp.Value?.Invoke(a, b);
-                }
-                catch (Exception ex)
-                {
-                    logger?.LogError(ex, $"An exception occurred while invoking action with param types {typeof(A).Name}, {typeof(B).Name}");
-                }
-            }
-        }
-        public static void InvokeAll<A, B, C>(this ConcurrentDictionary<Assembly, Action<A, B, C>> dict, Assembly assembly, A a, B b, C c, ILogger logger = null)
-        {
-            foreach (var kvp in dict)
-            {
-                if (kvp.Key == assembly)
-                {
-                    continue;
-                }
-                try
-                {
-                    kvp.Value?.Invoke(a, b, c);
-                }
-                catch (Exception ex)
-                {
-                    logger?.LogError(ex, $"An exception occurred while invoking action with param types {typeof(A).Name}, {typeof(B).Name}, {typeof(C).Name}");
-                }
-            }
-        }
-    }
+		public static void AddAction<A, B>(this ConcurrentDictionary<Assembly, Action<A, B>> dict, Assembly assembly, Action<A, B> value)
+		{
+			dict.AddOrUpdate(assembly, value, (callingAssembly, existingActions) => existingActions + value);
+		}
+
+		public static void AddAction<A, B, C>(this ConcurrentDictionary<Assembly, Action<A, B, C>> dict, Assembly assembly, Action<A, B, C> value)
+		{
+			dict.AddOrUpdate(assembly, value, (callingAssembly, existingActions) => existingActions + value);
+		}
+
+		public static void RemoveAction(this ConcurrentDictionary<Assembly, Action> dict, Assembly assembly, Action value)
+		{
+            if (!dict.TryGetValue(assembly, out var action))
+			{
+				return;
+			}
+            action -= value;
+		}
+		public static void RemoveAction<A>(this ConcurrentDictionary<Assembly, Action<A>> dict, Assembly assembly, Action<A> value)
+		{
+            if (!dict.TryGetValue(assembly, out var action))
+			{
+				return;
+			}
+            action -= value;
+		}
+		public static void RemoveAction<A, B>(this ConcurrentDictionary<Assembly, Action<A, B>> dict, Assembly assembly, Action<A, B> value)
+		{
+            if (!dict.TryGetValue(assembly, out var action))
+			{
+				return;
+			}
+            action -= value;
+		}
+		public static void RemoveAction<A, B, C>(this ConcurrentDictionary<Assembly, Action<A, B, C>> dict, Assembly assembly, Action<A, B, C> value)
+		{
+            if (!dict.TryGetValue(assembly, out var action))
+			{
+				return;
+			}
+            action -= value;
+		}
+
+		public static void InvokeAll(this ConcurrentDictionary<Assembly, Action> dict, Assembly assembly, ILogger logger = null)
+		{
+			foreach (var kvp in dict)
+			{
+				if (kvp.Key == assembly)
+				{
+					continue;
+				}
+				try
+				{
+					kvp.Value?.Invoke();
+				}
+				catch (Exception ex)
+				{
+					logger?.LogError(ex, $"An exception occurred while invoking action no params.");
+				}
+			}
+		}
+		public static void InvokeAll<A>(this ConcurrentDictionary<Assembly, Action<A>> dict, Assembly assembly, A a, ILogger logger = null)
+		{
+			foreach (var kvp in dict)
+			{
+				if (kvp.Key == assembly)
+				{
+					continue;
+				}
+				try
+				{
+					kvp.Value?.Invoke(a);
+				}
+				catch (Exception ex)
+				{
+					logger?.LogError(ex, $"An exception occurred while invoking action with param type {typeof(A).Name}");
+				}
+			}
+		}
+		public static void InvokeAll<A, B>(this ConcurrentDictionary<Assembly, Action<A, B>> dict, Assembly assembly, A a, B b, ILogger logger = null)
+		{
+			foreach (var kvp in dict)
+			{
+				if (kvp.Key == assembly)
+				{
+					continue;
+				}
+				try
+				{
+					kvp.Value?.Invoke(a, b);
+				}
+				catch (Exception ex)
+				{
+					logger?.LogError(ex, $"An exception occurred while invoking action with param types {typeof(A).Name}, {typeof(B).Name}");
+				}
+			}
+		}
+		public static void InvokeAll<A, B, C>(this ConcurrentDictionary<Assembly, Action<A, B, C>> dict, Assembly assembly, A a, B b, C c, ILogger logger = null)
+		{
+			foreach (var kvp in dict)
+			{
+				if (kvp.Key == assembly)
+				{
+					continue;
+				}
+				try
+				{
+					kvp.Value?.Invoke(a, b, c);
+				}
+				catch (Exception ex)
+				{
+					logger?.LogError(ex, $"An exception occurred while invoking action with param types {typeof(A).Name}, {typeof(B).Name}, {typeof(C).Name}");
+				}
+			}
+		}
+	}
 }

--- a/ChatCore/Utilities/DictionaryUtils.cs
+++ b/ChatCore/Utilities/DictionaryUtils.cs
@@ -31,35 +31,42 @@ namespace ChatCore
 
 		public static void RemoveAction(this ConcurrentDictionary<Assembly, Action> dict, Assembly assembly, Action value)
 		{
-            if (!dict.TryGetValue(assembly, out var action))
+			if (!dict.TryGetValue(assembly, out _))
 			{
 				return;
 			}
-            action -= value;
+
+			dict[assembly] -= value;
 		}
+
 		public static void RemoveAction<A>(this ConcurrentDictionary<Assembly, Action<A>> dict, Assembly assembly, Action<A> value)
 		{
-            if (!dict.TryGetValue(assembly, out var action))
+			if (!dict.TryGetValue(assembly, out _))
 			{
 				return;
 			}
-            action -= value;
+
+			dict[assembly] -= value;
 		}
+
 		public static void RemoveAction<A, B>(this ConcurrentDictionary<Assembly, Action<A, B>> dict, Assembly assembly, Action<A, B> value)
 		{
-            if (!dict.TryGetValue(assembly, out var action))
+			if (!dict.TryGetValue(assembly, out _))
 			{
 				return;
 			}
-            action -= value;
+
+			dict[assembly] -= value;
 		}
+
 		public static void RemoveAction<A, B, C>(this ConcurrentDictionary<Assembly, Action<A, B, C>> dict, Assembly assembly, Action<A, B, C> value)
 		{
-            if (!dict.TryGetValue(assembly, out var action))
+			if (!dict.TryGetValue(assembly, out _))
 			{
 				return;
 			}
-            action -= value;
+
+			dict[assembly] -= value;
 		}
 
 		public static void InvokeAll(this ConcurrentDictionary<Assembly, Action> dict, Assembly assembly, ILogger logger = null)
@@ -70,6 +77,7 @@ namespace ChatCore
 				{
 					continue;
 				}
+
 				try
 				{
 					kvp.Value?.Invoke();
@@ -80,6 +88,7 @@ namespace ChatCore
 				}
 			}
 		}
+
 		public static void InvokeAll<A>(this ConcurrentDictionary<Assembly, Action<A>> dict, Assembly assembly, A a, ILogger logger = null)
 		{
 			foreach (var kvp in dict)
@@ -88,6 +97,7 @@ namespace ChatCore
 				{
 					continue;
 				}
+
 				try
 				{
 					kvp.Value?.Invoke(a);
@@ -98,6 +108,7 @@ namespace ChatCore
 				}
 			}
 		}
+
 		public static void InvokeAll<A, B>(this ConcurrentDictionary<Assembly, Action<A, B>> dict, Assembly assembly, A a, B b, ILogger logger = null)
 		{
 			foreach (var kvp in dict)
@@ -106,6 +117,7 @@ namespace ChatCore
 				{
 					continue;
 				}
+
 				try
 				{
 					kvp.Value?.Invoke(a, b);
@@ -116,6 +128,7 @@ namespace ChatCore
 				}
 			}
 		}
+
 		public static void InvokeAll<A, B, C>(this ConcurrentDictionary<Assembly, Action<A, B, C>> dict, Assembly assembly, A a, B b, C c, ILogger logger = null)
 		{
 			foreach (var kvp in dict)
@@ -124,6 +137,7 @@ namespace ChatCore
 				{
 					continue;
 				}
+
 				try
 				{
 					kvp.Value?.Invoke(a, b, c);

--- a/ChatCore/Utilities/DictionaryUtils.cs
+++ b/ChatCore/Utilities/DictionaryUtils.cs
@@ -1,9 +1,7 @@
 ﻿using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Reflection;
-using System.Text;
 
 namespace ChatCore
 {
@@ -31,42 +29,34 @@ namespace ChatCore
 
 		public static void RemoveAction(this ConcurrentDictionary<Assembly, Action> dict, Assembly assembly, Action value)
 		{
-			if (!dict.TryGetValue(assembly, out _))
+			if (dict.ContainsKey(assembly))
 			{
-				return;
+				dict[assembly] -= value;
 			}
-
-			dict[assembly] -= value;
 		}
 
 		public static void RemoveAction<A>(this ConcurrentDictionary<Assembly, Action<A>> dict, Assembly assembly, Action<A> value)
 		{
-			if (!dict.TryGetValue(assembly, out _))
+			if (dict.ContainsKey(assembly))
 			{
-				return;
+				dict[assembly] -= value;
 			}
-
-			dict[assembly] -= value;
 		}
 
 		public static void RemoveAction<A, B>(this ConcurrentDictionary<Assembly, Action<A, B>> dict, Assembly assembly, Action<A, B> value)
 		{
-			if (!dict.TryGetValue(assembly, out _))
+			if (dict.ContainsKey(assembly))
 			{
-				return;
+				dict[assembly] -= value;
 			}
-
-			dict[assembly] -= value;
 		}
 
 		public static void RemoveAction<A, B, C>(this ConcurrentDictionary<Assembly, Action<A, B, C>> dict, Assembly assembly, Action<A, B, C> value)
 		{
-			if (!dict.TryGetValue(assembly, out _))
+			if (dict.ContainsKey(assembly))
 			{
-				return;
+				dict[assembly] -= value;
 			}
-
-			dict[assembly] -= value;
 		}
 
 		public static void InvokeAll(this ConcurrentDictionary<Assembly, Action> dict, Assembly assembly, ILogger logger = null)


### PR DESCRIPTION
I stumbled upon some bugs related to subscribing and unsubscribing of eventhandlers so I fixed it.
- Adding multiple eventhandler subscribers to the same eventhandler from the same calling assembly resulting in only the first one getting subscribed.
- Unsubscribing an en eventhandler subscriber didn't actually unsubscribe at all.

The old behaviour can be reproduced with the code below.
```csharp
class Program
{
	static async Task Main(string[] args)
	{
		Console.WriteLine("Hello World!");

		void Method1(IChatService chatService, IChatMessage message)
		{
			Console.WriteLine($"Hello from {nameof(Method1)}");
			Console.WriteLine(message.Message);
		}

		void Method2(IChatService chatService, IChatMessage message)
		{
			Console.WriteLine($"Hello from {nameof(Method2)}");
			Console.WriteLine(message.Message);
		}

		var chatCore = ChatCoreInstance.Create();
		var twitchService = chatCore.RunTwitchServices();
		twitchService.OnJoinChannel += (service, channel) => Console.WriteLine($"Joined channel {channel.Name}");
		twitchService.JoinChannel("RealEris");

		Console.WriteLine($"Subscribing to {nameof(Method1)} and {nameof(Method2)}");
		twitchService.OnTextMessageReceived += Method1;
		twitchService.OnTextMessageReceived += Method2;

		await Task.Delay(15_000).ConfigureAwait(false);

		Console.WriteLine($"Unsubscribing {nameof(Method1)}");
		twitchService.OnTextMessageReceived -= Method1;
		Console.WriteLine($"Done (un)subscribing, ready for testing again");

		await Task.Delay(15_000).ConfigureAwait(false);
		
		Console.WriteLine($"Unsubscribing {nameof(Method2)} and stopping {nameof(twitchService)} for current assembly");
		twitchService.OnTextMessageReceived -= Method2;
		chatCore.StopTwitchServices();
		Console.WriteLine($"{nameof(twitchService)} should now be stopped for current assembly");

		Console.WriteLine("Exiting...");
	}
}
```